### PR TITLE
avoid undefined process in webpack v5

### DIFF
--- a/lib/byte-utils.js
+++ b/lib/byte-utils.js
@@ -1,7 +1,7 @@
 // Use Uint8Array directly in the browser, use Buffer in Node.js but don't
 // speak its name directly to avoid bundlers pulling in the `Buffer` polyfill
 
-export const useBuffer = !process.browser && global.Buffer && typeof global.Buffer.isBuffer === 'function'
+export const useBuffer = typeof process !== 'undefined' && !process.browser && global.Buffer && typeof global.Buffer.isBuffer === 'function'
 
 const textDecoder = new TextDecoder()
 const textEncoder = new TextEncoder()


### PR DESCRIPTION
Webpack 5 no longer provides a polyfill for `process`. This adds a check so that we don't crash when immediately reaching for `process.browser`.