### PR TITLE
fix: avoid number-bigint mixed arithmetic 

### DIFF
--- a/lib/0uint.js
+++ b/lib/0uint.js
@@ -79,17 +79,21 @@ export function encodeUint (buf, token) {
 
 export function encodeUintValue (buf, major, uint) {
   if (uint < uintBoundaries[0]) {
+    const nuint = Number(uint)
     // pack into one byte, minor=0, additional=value
-    buf.push([major | uint])
+    buf.push([major | nuint])
   } else if (uint < uintBoundaries[1]) {
+    const nuint = Number(uint)
     // pack into two byte, minor=0, additional=24
-    buf.push([major | 24, uint])
+    buf.push([major | 24, nuint])
   } else if (uint < uintBoundaries[2]) {
+    const nuint = Number(uint)
     // pack into three byte, minor=0, additional=25
-    buf.push([major | 25, uint >>> 8, uint & 0xff])
+    buf.push([major | 25, nuint >>> 8, nuint & 0xff])
   } else if (uint < uintBoundaries[3]) {
+    const nuint = Number(uint)
     // pack into five byte, minor=0, additional=26
-    buf.push([major | 26, (uint >>> 24) & 0xff, (uint >>> 16) & 0xff, (uint >>> 8) & 0xff, uint & 0xff])
+    buf.push([major | 26, (nuint >>> 24) & 0xff, (nuint >>> 16) & 0xff, (nuint >>> 8) & 0xff, nuint & 0xff])
   } else {
     const buint = BigInt(uint)
     if (buint < uintBoundaries[4]) {

--- a/lib/jump.js
+++ b/lib/jump.js
@@ -180,12 +180,12 @@ export function quickEncodeToken (token) {
       return
     case Type.uint:
       if (token.value < 24) {
-        return fromArray([token.value])
+        return fromArray([Number(token.value)])
       }
       return
     case Type.negint:
       if (token.value >= -24) {
-        return fromArray([31 - token.value])
+        return fromArray([31 - Number(token.value)])
       }
   }
 }

--- a/test/test-0uint.js
+++ b/test/test-0uint.js
@@ -89,4 +89,15 @@ describe('uint', () => {
       }
     })
   })
+
+  describe('toosmall', () => {
+    for (const fixture of fixtures) {
+      if (fixture.strict !== false && typeof fixture.expected === 'number') {
+        const small = BigInt(fixture.expected)
+        it(`should encode ${small}n`, () => {
+          assert.strictEqual(toHex(encode(BigInt(small))), fixture.data, `encode ${small}`)
+        })
+      }
+    }
+  })
 })

--- a/test/test-1negint.js
+++ b/test/test-1negint.js
@@ -81,4 +81,15 @@ describe('negint', () => {
       }
     })
   })
+
+  describe('toosmall', () => {
+    for (const fixture of fixtures) {
+      if (fixture.strict !== false && typeof fixture.expected === 'number') {
+        const small = BigInt(fixture.expected)
+        it(`should encode ${small}n`, () => {
+          assert.strictEqual(toHex(encode(BigInt(small))), fixture.data, `encode ${small}`)
+        })
+      }
+    }
+  })
 })


### PR DESCRIPTION
```js
cborg.encode(500n)
```

encoding small bigints would crash with problems arising from operations like `123n >>> 8` or `uint8array[i] = 56n`