### PR TITLE
fix: add types entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,6 @@
     "./taglib": {
       "import": "./taglib.js"
     }
-  }
+  },
+  "types": "cborg.d.ts"
 }


### PR DESCRIPTION
Without this entry, you can't lookup types for cborg and you get this sort of error:

```
error TS2307: Cannot find module 'cborg' or its corresponding type declarations.

5 const cbor = require('cborg')
```