### PR TITLE
test: ensure BigInts are decoded as BigInts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:types": "npm run build:copy && cd dist && tsc --build",
     "test:cjs": "npm run build && mocha dist/cjs/node-test/test-*.js dist/cjs/node-test/node-test-*.js",
     "test:node": "c8 --check-coverage --branches 100 --functions 100 --lines 100 mocha test/test-*.js test/node-test-*.js",
-    "test:browser": "polendina --page --worker --serviceworker --cleanup dist/cjs/node-test/test-*.js",
+    "test:browser": "polendina --page --worker --serviceworker --cleanup dist/cjs/browser-test/test-*.js",
     "test": "npm run lint && npm run test:node && npm run test:cjs && npm run test:browser",
     "coverage": "c8 --reporter=html mocha test/test-*.js && npx st -d coverage -p 8080"
   },

--- a/test/test-bigint.js
+++ b/test/test-bigint.js
@@ -1,0 +1,20 @@
+/* eslint-env mocha */
+
+import chai from 'chai'
+
+import { decode, encode } from '../cborg.js'
+
+const { assert } = chai
+
+describe('bigint', () => {
+  describe('decode/encode', () => {
+    const data = {
+      foo: BigInt(12)
+    }
+
+    const encoded = encode(data)
+    const decoded = decode(encoded)
+
+    assert.strictEqual(decoded.foo, data.foo)
+  })
+})


### PR DESCRIPTION
If you encode an object with a BigInt property, you get a Number back when the buffer is decoded - is this intentional?

Also, the node tests appear to be run during `npm test:browser`?

This PR doesn't fix anything but does add a failing test as I'm not sure whether this is intended behaviour or not.