### PR TITLE
feat: handle JSON decoding of large integers as BigInt

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,10 @@ Use `import { encode, decode } from 'cborg/json'` or `const { encode, decode } =
 
 Many of the same encode and decode options available for CBOR can be used to manage JSON handling. These include strictness requirements for decode and custom tag encoders for encode. Tag encoders can't create new tags as there are no tags in JSON, but they can replace JavaScript object forms with custom JSON forms (e.g. convert a `Uint8Array` to a valid JSON form rather than having the encoder throw an error). The inverse is also possible, turning specific JSON forms into JavaScript forms, by using a custom tokenizer on decode.
 
+Special notes on options specific to the JSON:
+
+* Decoder `allowBigInt` option: is repurposed for the JSON decoder and defaults to `false`. When `false`, all numbers are decoded as `Number`, possibly losing precision when encountering numbers outside of the JavaScript safe integer range. When `true` numbers that have a decimal point (`.`, even if just `.0`) are returned as a `Number`, but for numbers without a decimal point _and_ that are outside of the JavaScript safe integer range, they are returned as `BigInt`s. This behaviour differs from CBOR decoding which will error when decoding integer and negative integer tokens that are outside of the JavaScript safe integer range if `allowBigInt` is `false`.
+
 See **[@ipld/dag-json](https://github.com/ipld/js-dag-json)** for an advanced use of the **cborg** JSON encoder and decoder including round-tripping of `Uint8Array`s and custom JavaScript classes (IPLD `CID` objects in this case).
 
 ### Example

--- a/lib/json/decode.js
+++ b/lib/json/decode.js
@@ -71,6 +71,7 @@ class Tokenizer {
   parseNumber () {
     const startPos = this.pos
     let negative = false
+    let float = false
 
     /**
      * @param {number[]} chars
@@ -95,6 +96,7 @@ class Tokenizer {
       this.pos++
       if (this.ch() === 46) { // '.'
         this.pos++
+        float = true
       } else {
         return new Token(Type.uint, 0, this.pos - startPos)
       }
@@ -104,20 +106,31 @@ class Tokenizer {
       throw new Error(`${decodeErrPrefix} unexpected token at position ${this.pos}`)
     }
     if (!this.done() && this.ch() === 46) { // '.'
+      if (float) {
+        throw new Error(`${decodeErrPrefix} unexpected token at position ${this.pos}`)
+      }
+      float = true
       this.pos++
       swallow([48, 49, 50, 51, 52, 53, 54, 55, 56, 57]) // DIGIT
     }
     if (!this.done() && (this.ch() === 101 || this.ch() === 69)) { // '[eE]'
+      float = true
       this.pos++
       if (!this.done() && (this.ch() === 43 || this.ch() === 45)) { // '+', '-'
         this.pos++
       }
       swallow([48, 49, 50, 51, 52, 53, 54, 55, 56, 57]) // DIGIT
     }
-    // TODO: check canonical form of this number?
     // @ts-ignore
-    const float = parseFloat(String.fromCharCode.apply(null, this.data.subarray(startPos, this.pos)))
-    return new Token(Number.isInteger(float) ? float >= 0 ? Type.uint : Type.negint : Type.float, float, this.pos - startPos)
+    const numStr = String.fromCharCode.apply(null, this.data.subarray(startPos, this.pos))
+    const num = parseFloat(numStr)
+    if (float) {
+      return new Token(Type.float, num, this.pos - startPos)
+    }
+    if (Number.isSafeInteger(num)) {
+      return new Token(num >= 0 ? Type.uint : Type.negint, num, this.pos - startPos)
+    }
+    return new Token(num >= 0 ? Type.uint : Type.negint, BigInt(numStr), this.pos - startPos)
   }
 
   /**

--- a/lib/json/decode.js
+++ b/lib/json/decode.js
@@ -127,7 +127,7 @@ class Tokenizer {
     if (float) {
       return new Token(Type.float, num, this.pos - startPos)
     }
-    if (Number.isSafeInteger(num)) {
+    if (this.options.allowBigInt !== true || Number.isSafeInteger(num)) {
       return new Token(num >= 0 ? Type.uint : Type.negint, num, this.pos - startPos)
     }
     return new Token(num >= 0 ? Type.uint : Type.negint, BigInt(numStr), this.pos - startPos)

--- a/test/test-1negint.js
+++ b/test/test-1negint.js
@@ -24,7 +24,8 @@ const fixtures = [
   // kind of hard to assert on these (TODO: improve bignum handling)
   { data: '3b001fffffffffffff', expected: BigInt('-9007199254740992') /* Number.MIN_SAFE_INTEGER - 1 */, type: 'negint64' },
   { data: '3b0020000000000000', expected: BigInt('-9007199254740993') /* Number.MIN_SAFE_INTEGER - 2 */, type: 'negint64' },
-  { data: '3ba5f702b3a5f702b3', expected: BigInt('-11959030306112471732'), type: 'negint64' }
+  { data: '3ba5f702b3a5f702b3', expected: BigInt('-11959030306112471732'), type: 'negint64' },
+  { data: '3bffffffffffffffff', expected: BigInt('-18446744073709551616'), type: 'negint64' }
 ]
 
 describe('negint', () => {

--- a/test/test-json.js
+++ b/test/test-json.js
@@ -58,6 +58,32 @@ describe('json basics', () => {
     verifyRoundTrip(1.0011111e-18)
   })
 
+  it('handles large integers as BigInt', () => {
+    const verify = (inp, str) => {
+      if (str === undefined) {
+        str = String(inp)
+      }
+      assert.strictEqual(decode(toBytes(str)), inp)
+    }
+    verify(Number.MAX_SAFE_INTEGER)
+    verify(-Number.MAX_SAFE_INTEGER)
+    verify(BigInt('9007199254740992')) // Number.MAX_SAFE_INTEGER+1
+    verify(BigInt('9007199254740993'))
+    verify(BigInt('11959030306112471731'))
+    verify(BigInt('18446744073709551615')) // max uint64
+    verify(BigInt('9223372036854775807')) // max int64
+    verify(BigInt('-9007199254740992'))
+    verify(BigInt('-9007199254740993'))
+    verify(BigInt('-9223372036854776000')) // min int64
+    verify(BigInt('-11959030306112471732'))
+    verify(BigInt('-18446744073709551616')) // min -uint64
+
+    // these are "floats", distinct from "ints" which wouldn't have the `.` in them
+    verify(-9007199254740992, '-9007199254740992.0')
+    verify(-9223372036854776000, '-9223372036854776000.0')
+    verify(-18446744073709551616, '-18446744073709551616.0')
+  })
+
   it('can round-trip string literals', () => {
     const testCases = [
       JSON.stringify(''),
@@ -154,5 +180,6 @@ describe('json basics', () => {
     assert.throws(() => decode(toBytes('[tr]')), 'CBOR decode error: unexpected end of input at position 1')
     assert.throws(() => decode(toBytes('{"v":flase}')), 'CBOR decode error: unexpected token at position 7, expected to find \'false\'')
     assert.throws(() => decode(toBytes('[fa]')), 'CBOR decode error: unexpected end of input at position 1')
+    assert.throws(() => decode(toBytes('-0..1')), 'CBOR decode error: unexpected token at position 3')
   })
 })

--- a/test/test-json.js
+++ b/test/test-json.js
@@ -63,7 +63,8 @@ describe('json basics', () => {
       if (str === undefined) {
         str = String(inp)
       }
-      assert.strictEqual(decode(toBytes(str)), inp)
+      assert.strictEqual(decode(toBytes(str), { allowBigInt: true }), inp)
+      assert.strictEqual(decode(toBytes(str)), parseFloat(str)) // no BigInt for you
     }
     verify(Number.MAX_SAFE_INTEGER)
     verify(-Number.MAX_SAFE_INTEGER)


### PR DESCRIPTION
use the `allowBigInt` decoding option to make this a non-breaking change.