### PR TITLE
fix: add a decimal point for whole number float tokens

### DIFF
--- a/lib/json/encode.js
+++ b/lib/json/encode.js
@@ -135,8 +135,34 @@ class JSONEncoder extends Array {
     if (token.value === undefined) {
       throw new Error(`${encodeErrPrefix} unsupported type: undefined`)
     }
-    // @ts-ignore hack
-    this[Type.uint.major](buf, token)
+
+    this.prefix(buf)
+    if (token.type.name === 'true') {
+      buf.push([116, 114, 117, 101]) // 'true'
+      return
+    } else if (token.type.name === 'false') {
+      buf.push([102, 97, 108, 115, 101]) // 'false'
+      return
+    } else if (token.type.name === 'null') {
+      buf.push([110, 117, 108, 108]) // 'null'
+      return
+    }
+
+    // number
+    const is = String(token.value)
+    const isa = []
+    let dp = false
+    for (let i = 0; i < is.length; i++) {
+      isa[i] = is.charCodeAt(i)
+      if (!dp && (isa[i] === 46 || isa[i] === 101 || isa[i] === 69)) { // '[.eE]'
+        dp = true
+      }
+    }
+    if (!dp) { // need a decimal point for floats
+      isa.push(46) // '.'
+      isa.push(48) // '0'
+    }
+    buf.push(isa)
   }
 }
 


### PR DESCRIPTION
this shouldn't impact standard json.encode() operations as we
can't differentiate float from int for whole numbers, it only
impacts cases where a token stream is directly provided.