### PR TITLE
fix: rework lib/bin.js inclusion in ipjx compile chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "chai": "^4.3.4",
     "ipjs": "^5.2.0",
     "ipld-garbage": "^4.0.10",
-    "mocha": "^9.1.3",
+    "mocha": "^10.0.0",
     "polendina": "~3.1.0",
     "standard": "^17.0.0",
     "typescript": "~4.6.2"

--- a/test/node-test-bin.js
+++ b/test/node-test-bin.js
@@ -6,8 +6,6 @@ import process from 'process'
 import path from 'path'
 import { platform } from 'os'
 import { fileURLToPath } from 'url'
-// included here for ipjs compile tree
-import bin from '../lib/bin.js' // eslint-disable-line
 
 const { assert } = chai
 

--- a/test/noop-bin-test.js
+++ b/test/noop-bin-test.js
@@ -1,0 +1,3 @@
+// file included so ipjs will compile ../lib/bin.js
+// this test file is not intended to be run or loaded
+import bin from '../lib/bin.js' // eslint-disable-line


### PR DESCRIPTION
* was included as an import in test/node-test-bin.js just to get it in the
  compile chain
* mocha now doing ESM (I think) is loading node-test-bin.js as ESM and it's
  executing bin.js as it's loaded -- this didn't happen prior to mocha@10
* only seeing this in CI for Windows, could be to do with the way mocha is
  loaded for now
* moving the import to test/noop-bin-test.js which isn't run as part of the
  test suite, but will be picked up by `ipjs --tests`

PR also includes #53