### PR TITLE
perf: faster utf8ToBytes

### DIFF
--- a/lib/byte-utils.js
+++ b/lib/byte-utils.js
@@ -293,8 +293,8 @@ function utf8ToBytes (str) {
       out[p++] = (c >> 6) | 192
       out[p++] = (c & 63) | 128
     } else if (
-        ((c & 0xFC00) == 0xD800) && (i + 1) < str.length &&
-        ((str.charCodeAt(i + 1) & 0xFC00) == 0xDC00)) {
+        ((c & 0xFC00) === 0xD800) && (i + 1) < str.length &&
+        ((str.charCodeAt(i + 1) & 0xFC00) === 0xDC00)) {
       // Surrogate Pair
       c = 0x10000 + ((c & 0x03FF) << 10) + (str.charCodeAt(++i) & 0x03FF)
       out[p++] = (c >> 18) | 240

--- a/lib/byte-utils.js
+++ b/lib/byte-utils.js
@@ -293,8 +293,8 @@ function utf8ToBytes (str) {
       out[p++] = (c >> 6) | 192
       out[p++] = (c & 63) | 128
     } else if (
-        ((c & 0xFC00) === 0xD800) && (i + 1) < str.length &&
-        ((str.charCodeAt(i + 1) & 0xFC00) === 0xDC00)) {
+      ((c & 0xFC00) === 0xD800) && (i + 1) < str.length &&
+      ((str.charCodeAt(i + 1) & 0xFC00) === 0xDC00)) {
       // Surrogate Pair
       c = 0x10000 + ((c & 0x03FF) << 10) + (str.charCodeAt(++i) & 0x03FF)
       out[p++] = (c >> 18) | 240

--- a/lib/byte-utils.js
+++ b/lib/byte-utils.js
@@ -275,100 +275,43 @@ export function compare (b1, b2) {
   return 0
 }
 
-// The below code is mostly taken from https://github.com/feross/buffer
-// Licensed MIT. Copyright (c) Feross Aboukhadijeh
+// The below code is taken from https://github.com/google/closure-library/blob/8598d87242af59aac233270742c8984e2b2bdbe0/closure/goog/crypt/crypt.js#L117-L143
+// Licensed Apache-2.0.
 
 /**
- * @param {string} string
- * @param {number} [units]
+ * @param {string} str
  * @returns {number[]}
  */
-function utf8ToBytes (string, units = Infinity) {
-  let codePoint
-  const length = string.length
-  let leadSurrogate = null
-  const bytes = []
-
-  for (let i = 0; i < length; ++i) {
-    codePoint = string.charCodeAt(i)
-
-    // is surrogate component
-    if (codePoint > 0xd7ff && codePoint < 0xe000) {
-      // last char was a lead
-      if (!leadSurrogate) {
-        // no lead yet
-        /* c8 ignore next 9 */
-        if (codePoint > 0xdbff) {
-          // unexpected trail
-          if ((units -= 3) > -1) bytes.push(0xef, 0xbf, 0xbd)
-          continue
-        } else if (i + 1 === length) {
-          // unpaired lead
-          if ((units -= 3) > -1) bytes.push(0xef, 0xbf, 0xbd)
-          continue
-        }
-
-        // valid lead
-        leadSurrogate = codePoint
-
-        continue
-      }
-
-      // 2 leads in a row
-      /* c8 ignore next 5 */
-      if (codePoint < 0xdc00) {
-        if ((units -= 3) > -1) bytes.push(0xef, 0xbf, 0xbd)
-        leadSurrogate = codePoint
-        continue
-      }
-
-      // valid surrogate pair
-      codePoint = (leadSurrogate - 0xd800 << 10 | codePoint - 0xdc00) + 0x10000
-    /* c8 ignore next 4 */
-    } else if (leadSurrogate) {
-      // valid bmp char, but last char was a lead
-      if ((units -= 3) > -1) bytes.push(0xef, 0xbf, 0xbd)
-    }
-
-    leadSurrogate = null
-
-    // encode utf8
-    if (codePoint < 0x80) {
-      /* c8 ignore next 1 */
-      if ((units -= 1) < 0) break
-      bytes.push(codePoint)
-    } else if (codePoint < 0x800) {
-      /* c8 ignore next 1 */
-      if ((units -= 2) < 0) break
-      bytes.push(
-        codePoint >> 0x6 | 0xc0,
-        codePoint & 0x3f | 0x80
-      )
-    } else if (codePoint < 0x10000) {
-      /* c8 ignore next 1 */
-      if ((units -= 3) < 0) break
-      bytes.push(
-        codePoint >> 0xc | 0xe0,
-        codePoint >> 0x6 & 0x3f | 0x80,
-        codePoint & 0x3f | 0x80
-      )
-    /* c8 ignore next 9 */
-    } else if (codePoint < 0x110000) {
-      if ((units -= 4) < 0) break
-      bytes.push(
-        codePoint >> 0x12 | 0xf0,
-        codePoint >> 0xc & 0x3f | 0x80,
-        codePoint >> 0x6 & 0x3f | 0x80,
-        codePoint & 0x3f | 0x80
-      )
+function utf8ToBytes (str) {
+  const out = []
+  let p = 0
+  for (let i = 0; i < str.length; i++) {
+    let c = str.charCodeAt(i)
+    if (c < 128) {
+      out[p++] = c
+    } else if (c < 2048) {
+      out[p++] = (c >> 6) | 192
+      out[p++] = (c & 63) | 128
+    } else if (
+        ((c & 0xFC00) == 0xD800) && (i + 1) < str.length &&
+        ((str.charCodeAt(i + 1) & 0xFC00) == 0xDC00)) {
+      // Surrogate Pair
+      c = 0x10000 + ((c & 0x03FF) << 10) + (str.charCodeAt(++i) & 0x03FF)
+      out[p++] = (c >> 18) | 240
+      out[p++] = ((c >> 12) & 63) | 128
+      out[p++] = ((c >> 6) & 63) | 128
+      out[p++] = (c & 63) | 128
     } else {
-      /* c8 ignore next 2 */
-      throw new Error('Invalid code point')
+      out[p++] = (c >> 12) | 224
+      out[p++] = ((c >> 6) & 63) | 128
+      out[p++] = (c & 63) | 128
     }
   }
-
-  return bytes
+  return out
 }
+
+// The below code is mostly taken from https://github.com/feross/buffer
+// Licensed MIT. Copyright (c) Feross Aboukhadijeh
 
 /**
  * @param {Uint8Array} buf


### PR DESCRIPTION
The google closure library code seems to be a bit faster (at least in Node.js 20) when encoding strings. Here's the benchmark results:

Before:

```
rnd-100 @ 1,000
        encode (avg 87 b): cborg @ 501,786 op/s / borc @ 611,768 op/s = 82 %
        decode (avg 87 b): cborg @ 994,432 op/s / borc @ 785,126 op/s = 126.7 %
rnd-300 @ 1,000
        encode (avg 221 b): cborg @ 351,840 op/s / borc @ 418,766 op/s = 84 %
        decode (avg 221 b): cborg @ 639,305 op/s / borc @ 537,438 op/s = 119 %
rnd-nomap-300 @ 1,000
        encode (avg 174 b): cborg @ 595,479 op/s / borc @ 953,550 op/s = 62.4 %
        decode (avg 174 b): cborg @ 1,031,100 op/s / borc @ 796,402 op/s = 129.5 %
rnd-nolist-300 @ 1,000
        encode (avg 182 b): cborg @ 428,120 op/s / borc @ 468,517 op/s = 91.4 %
        decode (avg 182 b): cborg @ 701,533 op/s / borc @ 630,846 op/s = 111.2 %
rnd-nofloat-300 @ 1,000
        encode (avg 238 b): cborg @ 382,259 op/s / borc @ 441,217 op/s = 86.6 %
        decode (avg 238 b): cborg @ 598,776 op/s / borc @ 548,000 op/s = 109.3 %
rnd-nomaj7-300 @ 1,000
        encode (avg 289 b): cborg @ 347,182 op/s / borc @ 396,923 op/s = 87.5 %
        decode (avg 289 b): cborg @ 537,736 op/s / borc @ 470,637 op/s = 114.3 %
rnd-nostr-300 @ 1,000
        encode (avg 162 b): cborg @ 197,778 op/s / borc @ 218,994 op/s = 90.3 %
        decode (avg 162 b): cborg @ 425,106 op/s / borc @ 390,528 op/s = 108.9 %
rnd-nostrbyts-300 @ 1,000
        encode (avg 212 b): cborg @ 291,952 op/s / borc @ 330,116 op/s = 88.4 %
        decode (avg 212 b): cborg @ 529,095 op/s / borc @ 414,904 op/s = 127.5 %
rnd-1000 @ 1,000
        encode (avg 650 b): cborg @ 253,876 op/s / borc @ 294,910 op/s = 86.1 %
        decode (avg 650 b): cborg @ 369,990 op/s / borc @ 346,720 op/s = 106.7 %
rnd-2000 @ 1,000
        encode (avg 1,297 b): cborg @ 191,292 op/s / borc @ 223,832 op/s = 85.5 %
        decode (avg 1,297 b): cborg @ 256,627 op/s / borc @ 248,979 op/s = 103.1 %
rnd-fil-100 @ 1,000
        encode (avg 71 b): cborg @ 832,995 op/s / borc @ 1,318,347 op/s = 63.2 %
        decode (avg 71 b): cborg @ 1,636,137 op/s / borc @ 1,073,745 op/s = 152.4 %
rnd-fil-300 @ 1,000
        encode (avg 186 b): cborg @ 656,655 op/s / borc @ 984,984 op/s = 66.7 %
        decode (avg 186 b): cborg @ 1,058,784 op/s / borc @ 757,680 op/s = 139.7 %
rnd-fil-500 @ 1,000
        encode (avg 291 b): cborg @ 607,246 op/s / borc @ 871,309 op/s = 69.7 %
        decode (avg 291 b): cborg @ 824,826 op/s / borc @ 666,586 op/s = 123.7 %
rnd-fil-1000 @ 1,000
        encode (avg 566 b): cborg @ 482,090 op/s / borc @ 670,950 op/s = 71.9 %
        decode (avg 566 b): cborg @ 597,394 op/s / borc @ 511,910 op/s = 116.7 %
rnd-fil-2000 @ 1,000
        encode (avg 1,125 b): cborg @ 346,957 op/s / borc @ 459,618 op/s = 75.5 %
        decode (avg 1,125 b): cborg @ 392,427 op/s / borc @ 359,280 op/s = 109.2 %
Avg encode: 79 %
Avg decode: 120 %
```

After:

```
rnd-100 @ 1,000
        encode (avg 80 b): cborg @ 540,512 op/s / borc @ 650,748 op/s = 83.1 %
        decode (avg 80 b): cborg @ 1,033,018 op/s / borc @ 806,323 op/s = 128.1 %
rnd-300 @ 1,000
        encode (avg 219 b): cborg @ 354,415 op/s / borc @ 422,385 op/s = 83.9 %
        decode (avg 219 b): cborg @ 632,121 op/s / borc @ 526,282 op/s = 120.1 %
rnd-nomap-300 @ 1,000
        encode (avg 168 b): cborg @ 628,091 op/s / borc @ 996,870 op/s = 63 %
        decode (avg 168 b): cborg @ 1,114,323 op/s / borc @ 859,677 op/s = 129.6 %
rnd-nolist-300 @ 1,000
        encode (avg 184 b): cborg @ 433,350 op/s / borc @ 460,816 op/s = 94 %
        decode (avg 184 b): cborg @ 703,953 op/s / borc @ 629,173 op/s = 111.9 %
rnd-nofloat-300 @ 1,000
        encode (avg 241 b): cborg @ 374,985 op/s / borc @ 421,557 op/s = 89 %
        decode (avg 241 b): cborg @ 619,200 op/s / borc @ 519,800 op/s = 119.1 %
rnd-nomaj7-300 @ 1,000
        encode (avg 287 b): cborg @ 335,238 op/s / borc @ 374,065 op/s = 89.6 %
        decode (avg 287 b): cborg @ 543,035 op/s / borc @ 449,825 op/s = 120.7 %
rnd-nostr-300 @ 1,000
        encode (avg 160 b): cborg @ 201,186 op/s / borc @ 220,835 op/s = 91.1 %
        decode (avg 160 b): cborg @ 425,784 op/s / borc @ 409,674 op/s = 103.9 %
rnd-nostrbyts-300 @ 1,000
        encode (avg 221 b): cborg @ 270,657 op/s / borc @ 294,528 op/s = 91.9 %
        decode (avg 221 b): cborg @ 471,058 op/s / borc @ 390,426 op/s = 120.7 %
rnd-1000 @ 1,000
        encode (avg 666 b): cborg @ 248,493 op/s / borc @ 275,662 op/s = 90.1 %
        decode (avg 666 b): cborg @ 346,850 op/s / borc @ 331,985 op/s = 104.5 %
rnd-2000 @ 1,000
        encode (avg 1,335 b): cborg @ 179,015 op/s / borc @ 198,004 op/s = 90.4 %
        decode (avg 1,335 b): cborg @ 247,505 op/s / borc @ 247,008 op/s = 100.2 %
rnd-fil-100 @ 1,000
        encode (avg 70 b): cborg @ 832,064 op/s / borc @ 1,325,500 op/s = 62.8 %
        decode (avg 70 b): cborg @ 1,631,088 op/s / borc @ 1,098,960 op/s = 148.4 %
rnd-fil-300 @ 1,000
        encode (avg 178 b): cborg @ 693,451 op/s / borc @ 1,031,356 op/s = 67.2 %
        decode (avg 178 b): cborg @ 1,126,998 op/s / borc @ 860,778 op/s = 130.9 %
rnd-fil-500 @ 1,000
        encode (avg 304 b): cborg @ 560,052 op/s / borc @ 802,534 op/s = 69.8 %
        decode (avg 304 b): cborg @ 878,805 op/s / borc @ 690,438 op/s = 127.3 %
rnd-fil-1000 @ 1,000
        encode (avg 582 b): cborg @ 465,134 op/s / borc @ 647,053 op/s = 71.9 %
        decode (avg 582 b): cborg @ 594,212 op/s / borc @ 504,974 op/s = 117.7 %
rnd-fil-2000 @ 1,000
        encode (avg 1,124 b): cborg @ 357,924 op/s / borc @ 468,591 op/s = 76.4 %
        decode (avg 1,124 b): cborg @ 400,198 op/s / borc @ 369,260 op/s = 108.4 %
Avg encode: 81 %
Avg decode: 119 %
```