### PR TITLE
add interface.d.ts to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
     "./json": {
       "import": "./lib/json/json.js",
       "types": "./types/lib/json/json.d.ts"
+    },
+    "./interface": {
+      "types": "./types/interface.d.ts"
     }
   },
   "types": "cborg.d.ts",


### PR DESCRIPTION
dag-json is importing it but i'm getting errors because it's not in the package.json exports

https://github.com/ipld/js-dag-json/blob/92e7cab3ab95a1ebe7de56bd4a81b39bf314e9f2/src/index.js#L16