### PR TITLE
Normalize package repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:rvagg/cborg.git"
+    "url": "git+https://github.com/rvagg/cborg.git"
   },
   "keywords": [
     "cbor"


### PR DESCRIPTION
## Summary
- update `package.json` repository metadata from an SSH-style GitHub URL to a public `git+https` URL
- leave runtime code, dependencies, package version, and package contents unchanged

## Validation
- metadata assertion for `package.json` repository URL
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`

Note: `npm pack` emits the existing `.npmignore` fallback warning for this package; the dry run exits successfully.