### PR TITLE
fix: emit shortest-form floats in rfc8949EncodeOptions (RFC 8949 4.2.1)

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -33,7 +33,6 @@ const defaultEncodeOptions = {
 
 /** @type {EncodeOptions} */
 export const rfc8949EncodeOptions = Object.freeze({
-  float64: true,
   mapSorter: rfc8949MapSorter,
   quickEncodeToken
 })

--- a/test/test-encode-rfc8949.js
+++ b/test/test-encode-rfc8949.js
@@ -27,6 +27,17 @@ describe('RFC8949 deterministic encoding', () => {
     // {10: 10, 100: 100, -1: -1, "z": "z", "aa": "aa", false: false}
   })
 
+  it('should encode floats in shortest form', () => {
+    // https://datatracker.ietf.org/doc/html/rfc8949#section-4.2.1
+    // "Floating-point values also MUST use the shortest form ... 1.5 is
+    //  encoded as 0xf93e00"
+    assert.deepEqual(toHex(encode(1.5, rfc8949EncodeOptions)), 'f93e00')
+    assert.deepEqual(toHex(encode(Infinity, rfc8949EncodeOptions)), 'f97c00')
+    assert.deepEqual(toHex(encode(NaN, rfc8949EncodeOptions)), 'f97e00')
+    // values that genuinely need 64 bits stay 64 bits
+    assert.deepEqual(toHex(encode(1.1, rfc8949EncodeOptions)), 'fb3ff199999999999a')
+  })
+
   it('will throw on complex key types', () => {
     const value = new Map()
     // https://datatracker.ietf.org/doc/html/rfc8949#section-4.2.1


### PR DESCRIPTION
_(edit @rvagg: irelevant text removed, copypasta from some other PR about gitignore regexes)_